### PR TITLE
Double whammy - allow overriding of the default queue and return the Mail::Message instead of a proxy

### DIFF
--- a/lib/resque_mailer/common.rb
+++ b/lib/resque_mailer/common.rb
@@ -2,7 +2,7 @@ module Resque
   module Mailer
 
     class << self
-      attr_accessor :default_queue_name
+      attr_accessor :default_queue_name, :default_queue
       attr_reader :excluded_environments
 
       def excluded_environments=(envs)
@@ -15,6 +15,7 @@ module Resque
     end
 
     self.default_queue_name = "mailer"
+    self.default_queue      = ::Resque
     self.excluded_environments = [:test]
 
     module ClassMethods
@@ -24,6 +25,10 @@ module Resque
 
       def queue
         ::Resque::Mailer.default_queue_name
+      end
+
+      def resque
+        ::Resque::Mailer.default_queue
       end
 
       def excluded_environment?(name)

--- a/lib/resque_mailer/rails3.rb
+++ b/lib/resque_mailer/rails3.rb
@@ -11,10 +11,12 @@ module Resque
 
         if action_methods.include?(method_name.to_s)
           mailer_class = self
+          resque = self.resque
+
           super.tap do |resque_mail|
             resque_mail.class_eval do
               define_method(:deliver) do
-                ::Resque.enqueue(mailer_class, method_name, *args)
+                resque.enqueue(mailer_class, method_name, *args)
                 self
               end
             end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -5,6 +5,21 @@ class CommonMailer
 end
 
 describe Resque::Mailer do
+  describe ".default_queue" do
+    before do
+      define_constant(:fake_resque) { }
+    end
+
+    it "defaults to resque as the default queue" do
+      Resque::Mailer.default_queue.should == ::Resque
+    end
+
+    it "allows overriding of the default queue" do
+      Resque::Mailer.default_queue = FakeResque
+      Resque::Mailer.default_queue.should == FakeResque
+    end
+  end
+
   describe ".queue" do
     context "when not changed" do
       it "should return 'mailer'" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'resque_mailer/common'
+require "support/define_constant_helpers"
 
 begin
   require 'rspec/autorun'

--- a/spec/support/define_constant_helpers.rb
+++ b/spec/support/define_constant_helpers.rb
@@ -1,0 +1,28 @@
+module DefineConstantHelpers
+  def define_constant(class_name, base = Object, &block)
+    class_name = class_name.to_s.camelize
+
+    klass = Class.new(base)
+    Object.const_set(class_name, klass)
+
+    klass.class_eval(&block) if block_given?
+
+    @defined_constants << class_name
+
+    klass
+  end
+end
+
+RSpec.configure do |config|
+  config.include DefineConstantHelpers
+
+  config.before do
+    @defined_constants = []
+  end
+
+  config.after do
+    @defined_constants.each do |class_name|
+      Object.send(:remove_const, class_name)
+    end
+  end
+end


### PR DESCRIPTION
The first part is pretty straightforward - it allows overriding of the default queue (which defaults to `::Resque`), so if you want to use a different queue (say, during testing), you can.

The other commit in this pull request calls the mailer normally but explicitly overrides `#deliver` to enqueue, then returns `self`. This follows the `Mail::Message#deliver` api by returning `self` and returns the normal `Mail::Message`  instance when just calling the method. The core use of this (for me, at least) has been to turn Resque::Mailer on during my tests and have RSpec matchers behave normally (instead of trying to call methods that don't exist [subject, to, from, cc, bcc, etc.] on the `Rails3MailerProxy`).
