### PR TITLE
proxy methods other than deliver in rails 3

### DIFF
--- a/lib/resque_mailer/rails3.rb
+++ b/lib/resque_mailer/rails3.rb
@@ -13,7 +13,21 @@ module Resque
       end
 
       def deliver!
-        @mailer_class.send(:new, @action, *@args).message.deliver
+        original_message.deliver
+      end
+
+      def respond_to?(method, *args)
+        super || original_message.respond_to?(method, *args)
+      end
+
+      def method_missing(method_name, *args)
+        original_message.send(method_name, *args)
+      end
+
+      protected
+
+      def original_message
+        @original_message ||= @mailer_class.send(:new, @action, *@args).message
       end
     end
 

--- a/spec/rails3_spec.rb
+++ b/spec/rails3_spec.rb
@@ -64,4 +64,11 @@ describe Rails3Mailer do
       }.should change(ActionMailer::Base.deliveries, :size).by(1)
     end
   end
+
+  describe "original message methods" do
+    it "should proxy methods other than deliver" do
+      Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS).from.should include 'from@example.org'
+      Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS).to.should include 'misio@example.org'
+    end
+  end
 end


### PR DESCRIPTION
Hi,
Great gem!
I had one problem. Without resque_mailer I can do something like:

MyMailer.test_mail('foo').body

(or instead of #body, #to #from #parts and so on). However when Resque::Mailer is included, this becomes impossible. This addition makes it works again. 
