### PR TITLE
Remove :test from excluded_environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ database-backed objects as parameters in your mailer and instead pass record
 identifiers. Then, in your delivery method, you can look up the record from
 the id and use it as needed.
 
-If you want to set a different default queue name for your mailer, you can 
+If you want to set a different default queue name for your mailer, you can
 change the <tt>default_queue_name</tt> property like so:
 
     # config/initializers/resque_mailer.rb
@@ -75,11 +75,11 @@ Install it as a plugin or as a gem plugin from Gemcutter:
 
 ## Testing
 
-You don't want to be sending actual emails in the test environment, so you can
-configure the environments that should be excluded like so:
+ActionMailer ensures you won't send out actual emails in the test environment. You can
+also configure other environments that should be excluded like so:
 
     # config/initializers/resque_mailer.rb
-    Resque::Mailer.excluded_environments = [:test, :cucumber]
+    Resque::Mailer.excluded_environments = [:cucumber]
 
 ## Note on Patches / Pull Requests
 

--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -15,7 +15,7 @@ module Resque
 
     self.default_queue_target = ::Resque
     self.default_queue_name = "mailer"
-    self.excluded_environments = [:test]
+    self.excluded_environments = []
 
     module ClassMethods
       def current_env


### PR DESCRIPTION
In my tests I want to be able to test something like this to be confident the mail is queued:

Resque.redis.flushall
MyMailer.welcome(@user.id).deliver
Resque.size(:mailer).should == 1
job = Resque.reserve(:mailer)
job.args.count.should == 2
job.args[0].should == 'welcome'
job.args[1].should == @user.id.to_s

I have to add a initializer and reset excluded environment with Resque::Mailer.excluded_environments = []. Adding :test to excluded_environments doesn't really help to prevent the mails from being delivered since ActionMailer::Base.delivery_method already does it.
