### PR TITLE
raise the previous exception instead of instantiating it again

### DIFF
--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -45,8 +45,8 @@ module Resque
             logger.error "Unable to deliver email [#{action}]: #{ex}"
             logger.error ex.backtrace.join("\n\t")
           end
-
-          raise ex.class, "Unable to deliver email: [#{ex.message}]", ex.backtrace
+          
+          raise ex
         end
       end
 


### PR DESCRIPTION
This pull request resolves Issue 40.  

The problem here was that in the following line (49)

raise ex.class, "Unable to deliver email: [#{ex.message}]", ex.backtrace

the exception passed through was being instantiated again.  Now, in the case of an ActionView::Template::Error, not enough arguments are being passed through in order to instantiate the exception object correctly,so the error 

ArgumentError: wrong number of arguments (1 for 3) was being thrown

simply reraising the exception object solves this problem and displays the correct error that was thrown in the view (for example a no method error).  
