### PR TITLE
Resque mailer with queue name param

### DIFF
--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -106,7 +106,7 @@ module Resque
         end
       end
       
-      def deliver_and_set_queue_name(queue_name)
+      def deliver_with_queue(queue_name)
         return deliver! if environment_excluded?
         if !queue_name.nil?
           ::Resque::Mailer.default_queue_name = queue_name

--- a/spec/resque_mailer_spec.rb
+++ b/spec/resque_mailer_spec.rb
@@ -80,7 +80,7 @@ describe Resque::Mailer do
     end
   end
 
-  describe '#deliver_and_set_queue_name' do
+  describe '#deliver_with_queue' do
     before(:all) do
       @queue_name = "test_queue"
       @delivery = lambda {
@@ -107,7 +107,7 @@ describe Resque::Mailer do
 
     it 'should not invoke the method body more than once' do
       Resque::Mailer.should_not_receive(:success!)
-      Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS).deliver_and_set_queue_name(@queue_name)
+      Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS).deliver_with_queue(@queue_name)
     end
   end
 


### PR DESCRIPTION
Hi Zapnap,

Hope you remember I opened an issue few days back for having different queue names for resque mailer.
I forked your code and added code to have one more deliver method which will take parameter as queue_name. I am newbie to ruby and if you feel I have done anything incorrect then please let me know. I will rectify the same.

I used your 2.1.0 tagged version to create this branch.

Regards,

Vishakha
