### PR TITLE
[#51] avoid lazy evaluation of mail when excluded

### DIFF
--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -84,6 +84,7 @@ module Resque
         @mailer_class = mailer_class
         @method_name = method_name
         *@args = *args
+        actual_message if environment_excluded?
       end
 
       def resque

--- a/spec/resque_mailer_spec.rb
+++ b/spec/resque_mailer_spec.rb
@@ -75,7 +75,7 @@ describe Resque::Mailer do
     context "when current env is excluded" do
       it 'should not deliver through Resque for excluded environments' do
         Resque::Mailer.stub(:excluded_environments => [:custom])
-        Resque::Mailer::MessageDecoy.any_instance.should_receive(:current_env).and_return(:custom)
+        Resque::Mailer::MessageDecoy.any_instance.should_receive(:current_env).twice.and_return(:custom)
         resque.should_not_receive(:enqueue)
         @delivery.call
       end
@@ -132,7 +132,7 @@ describe Resque::Mailer do
       context "when current env is excluded" do
         it 'should not deliver through Resque for excluded environments' do
           Resque::Mailer.stub(:excluded_environments => [:custom])
-          Resque::Mailer::MessageDecoy.any_instance.should_receive(:current_env).and_return(:custom)
+          Resque::Mailer::MessageDecoy.any_instance.should_receive(:current_env).twice.and_return(:custom)
           resque.should_not_receive(:enqueue_at)
           @delivery.call
         end
@@ -169,7 +169,7 @@ describe Resque::Mailer do
       context "when current env is excluded" do
         it 'should not deliver through Resque for excluded environments' do
           Resque::Mailer.stub(:excluded_environments => [:custom])
-          Resque::Mailer::MessageDecoy.any_instance.should_receive(:current_env).and_return(:custom)
+          Resque::Mailer::MessageDecoy.any_instance.should_receive(:current_env).twice.and_return(:custom)
           resque.should_not_receive(:enqueue_in)
           @delivery.call
         end
@@ -246,6 +246,16 @@ describe Resque::Mailer do
     it 'should require execution of the method body prior to queueing' do
       Resque::Mailer.should_receive(:success!).once
       Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS).subject
+    end
+    context "when current env is excluded" do
+      it 'should render email immediately' do
+        Resque::Mailer::MessageDecoy.any_instance.stub(:environment_excluded?).and_return(true)
+        resque.should_not_receive(:enqueue_in)
+        params = {:subject => 'abc'}
+        mail = Rails3Mailer.test_mail(params)
+        params[:subject] = 'xyz'
+        mail.to_s.should match('Subject: abc')
+      end
     end
   end
 end


### PR DESCRIPTION
- calling `actual_message` if resque_mailer is excluded
  to evaluate/memoize it immediately
- updated specs and added a test case for it
