### PR TITLE
MessageDecoy should handle non rails current_env.

### DIFF
--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -91,7 +91,11 @@ module Resque
       end
 
       def current_env
-        ::Rails.env
+        if defined?(Rails)
+          ::Resque::Mailer.current_env || ::Rails.env
+        else
+          ::Resque::Mailer.current_env
+        end
       end
 
       def environment_excluded?

--- a/spec/resque_mailer_spec.rb
+++ b/spec/resque_mailer_spec.rb
@@ -31,7 +31,7 @@ describe Resque::Mailer do
     Resque::Mailer.default_queue_target = resque
     Resque::Mailer.fallback_to_synchronous = false
     Resque::Mailer.stub(:success!)
-    Resque::Mailer::MessageDecoy.any_instance.stub(:current_env).and_return(:test)
+    Resque::Mailer.stub(:current_env => :test)
   end
 
   describe "resque" do


### PR DESCRIPTION
When using resque mailer outside of rails you get a blowup in MessageDecoy#current_env. Changed the current_env method to handle the Rails check the same as the Mailer class.
