### PR TITLE
Admit to responding to original mail methods

### DIFF
--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -174,6 +174,10 @@ module Resque
         actual_message.send(method_name, *args)
       end
 
+      def respond_to?(method_name, *args)
+        super || actual_message.respond_to?(method_name, *args)
+      end
+
       def logger
         @mailer_class.logger
       end

--- a/spec/resque_mailer_spec.rb
+++ b/spec/resque_mailer_spec.rb
@@ -335,4 +335,18 @@ describe Resque::Mailer do
       end
     end
   end
+
+  describe '#respond_to?' do
+    it 'should admit to responding to its own methods' do
+      Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS).respond_to?(:deliver_at).should be_truthy
+    end
+
+    it 'should admit to responding to original mail methods' do
+      Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS).respond_to?(:subject).should be_truthy
+    end
+
+    it 'should not admit to responding to non-existent methods' do
+      Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS).respond_to?(:definitely_not_a_method).should be_falsy
+    end
+  end
 end


### PR DESCRIPTION
Rounds out the duck typing, allowing consumers to ask the decoy if it will respond before attempting a particular method call.

This allows, e.g., `Rails::MailersController` to [ask the decoy if it has a `decoded` method](https://github.com/rails/rails/blob/6c5f43bab8206747a8591435b2aa0ff7051ad3de/railties/lib/rails/mailers_controller.rb#L29) that it can use to display a preview of the mail message.
