### PR TITLE
Rails 5 Compatibility

### DIFF
--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -118,7 +118,11 @@ module Resque
       end
 
       def actual_message
-        @actual_message ||= @mailer_class.send(:new, @method_name, *@args).message
+        @actual_message ||= begin
+          mailer_class_send = @mailer_class.send(:new)
+          mailer_class_send.process(@method_name, *@args)
+          mailer_class_send.message
+        end
       end
 
       def deliver

--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -47,7 +47,7 @@ module Resque
           args = ::Resque::Mailer.argument_serializer.deserialize(serialized_args)
           message = begin
             mailer_class_send = self.send(:new)
-            mailer_class_send.process(action, *@args)
+            mailer_class_send.process(action, *args)
             mailer_class_send.message
           end
 

--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -45,7 +45,12 @@ module Resque
       def perform(action, serialized_args)
         begin
           args = ::Resque::Mailer.argument_serializer.deserialize(serialized_args)
-          message = self.send(:new, action, *args).message
+          message ||= begin
+            mailer_class_send = @mailer_class.send(:new)
+            mailer_class_send.process(action, *@args)
+            mailer_class_send.message
+          end
+
           if message.respond_to?(:deliver_now)
             message.deliver_now
           else

--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -45,8 +45,8 @@ module Resque
       def perform(action, serialized_args)
         begin
           args = ::Resque::Mailer.argument_serializer.deserialize(serialized_args)
-          message ||= begin
-            mailer_class_send = @mailer_class.send(:new)
+          message = begin
+            mailer_class_send = self.send(:new)
             mailer_class_send.process(action, *@args)
             mailer_class_send.message
           end

--- a/spec/resque_mailer_spec.rb
+++ b/spec/resque_mailer_spec.rb
@@ -239,6 +239,8 @@ describe Resque::Mailer do
       let(:exception) { Exception.new("An error") }
 
       before(:each) do
+        mailer.stub(:process)
+        mailer.stub(:message) { message }
         Rails3Mailer.stub(:new) { mailer }
         message.stub(:deliver).and_raise(exception)
       end


### PR DESCRIPTION
In Rails 5 ActionMailer no longer automatically calls `process` when initialized so it needs to be called manually:

https://github.com/rails/rails/commit/e76c38ef1047ad3ffb25c1c639c38432a9228796