### PR TITLE
Fix for #95  RM with mailer block syntax leads to errors (symbolize keys) 

### DIFF
--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -51,6 +51,10 @@ module Resque
       def perform(action, serialized_args)
         begin
           args = ::Resque::Mailer.argument_serializer.deserialize(serialized_args)
+          # symbolize keys so mailer block syntax works
+          args = args.each_with_object([]) do |arg, o|
+            o << (arg.is_a?(Hash) ? arg.symbolize_keys : arg)
+          end
           message = ::Resque::Mailer.prepare_message(self, action, *args)
           if message.respond_to?(:deliver_now)
             message.deliver_now


### PR DESCRIPTION
Did not touch tests as this can only be tested with an integration test?