### PR TITLE
Added #deliver_now and #deliver_now! 

### DIFF
--- a/lib/resque_mailer.rb
+++ b/lib/resque_mailer.rb
@@ -145,6 +145,7 @@ module Resque
           end
         end
       end
+      alias_method :deliver_now, :deliver
 
       def deliver_at(time)
         return deliver! if environment_excluded?
@@ -185,6 +186,7 @@ module Resque
           actual_message.deliver
         end
       end
+      alias_method :deliver_now!, :deliver!
 
       def method_missing(method_name, *args)
         actual_message.send(method_name, *args)

--- a/spec/resque_mailer_spec.rb
+++ b/spec/resque_mailer_spec.rb
@@ -122,6 +122,20 @@ describe Resque::Mailer do
     end
   end
 
+  describe '#deliver_now' do
+    it 'has method_alias to #deliver' do
+      @message_decoy = Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS)
+      @message_decoy.method(:deliver_now) == @message_decoy.method(:deliver)
+    end
+  end
+
+  describe '#deliver_now!' do
+    it 'has method_alias to #deliver' do
+      @message_decoy = Rails3Mailer.test_mail(Rails3Mailer::MAIL_PARAMS)
+      @message_decoy.method(:deliver_now!) == @message_decoy.method(:deliver!)
+    end
+  end
+
   describe '#unschedule_delivery' do
     before(:all) do
       @unschedule = lambda {


### PR DESCRIPTION
Added method aliases to match the methods defined in ActionMailer for Rails 4.2 & 5
Fixes #98 